### PR TITLE
Open social media links in a new browser tab

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This plugin will only work with the [Storefront](http://wordpress.org/themes/sto
 
 == Changelog ==
 
+= 1.0.4 - xx.xx.2016 =
+* Tweak - Open social media links in a new browser tab.
+
 = 1.0.3 - 05.11.2016 =
 * Tweak - Adjusted design to better suit Storefront 2.0.
 

--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -215,9 +215,9 @@ final class Storefront_Product_Sharing {
 		?>
 		<div class="storefront-product-sharing">
 			<ul>
-				<li class="twitter"><a href="<?php echo esc_url( $twitter_url ); ?>"><?php _e( 'Share on Twitter', 'storefront-product-sharing' ); ?></a></li>
-				<li class="facebook"><a href="<?php echo esc_url( $facebook_url ); ?>"><?php _e( 'Share on Facebook', 'storefront-product-sharing' ); ?></a></li>
-				<li class="pinterest"><a href="<?php echo esc_url( $pinterest_url ); ?>"><?php _e( 'Pin this product', 'storefront-product-sharing' ); ?></a></li>
+				<li class="twitter"><a href="<?php echo esc_url( $twitter_url ); ?>" target="_blank"><?php _e( 'Share on Twitter', 'storefront-product-sharing' ); ?></a></li>
+				<li class="facebook"><a href="<?php echo esc_url( $facebook_url ); ?>" target="_blank"><?php _e( 'Share on Facebook', 'storefront-product-sharing' ); ?></a></li>
+				<li class="pinterest"><a href="<?php echo esc_url( $pinterest_url ); ?>" target="_blank"><?php _e( 'Pin this product', 'storefront-product-sharing' ); ?></a></li>
 				<li class="email"><a href="<?php echo esc_url( $email_url ); ?>"><?php _e( 'Share via Email', 'storefront-product-sharing' ); ?></a></li>
 			</ul>
 		</div>


### PR DESCRIPTION
It isn’t necessary to do this for email as far as I can tell.

Closes https://github.com/woocommerce/storefront-product-sharing/issues/4