### PR TITLE
Fix twitter url   issue #15

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jameskoster, woothemes, tiagonoronha
 Tags: woocommerce, ecommerce, storefront, social, sharing, seo
 Requires at least: 3.5
 Tested up to: 4.9
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,6 +32,9 @@ This plugin will only work with the [Storefront](http://wordpress.org/themes/sto
 1. The sharing buttons in action.
 
 == Changelog ==
+
+= 1.0.7 - 04.19.2018 =
+* Fix - Twitter share URL.
 
 = 1.0.6 - 04.19.2018 =
 * Fix - Compatibility with Storefront 2.3.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jameskoster, woothemes, tiagonoronha
 Tags: woocommerce, ecommerce, storefront, social, sharing, seo
 Requires at least: 3.5
 Tested up to: 4.9
-Stable tag: 1.0.7
+Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,9 +32,6 @@ This plugin will only work with the [Storefront](http://wordpress.org/themes/sto
 1. The sharing buttons in action.
 
 == Changelog ==
-
-= 1.0.7 - 04.19.2018 =
-* Fix - Twitter share URL.
 
 = 1.0.6 - 04.19.2018 =
 * Fix - Compatibility with Storefront 2.3.

--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -3,7 +3,7 @@
  * Plugin Name:         Storefront Product Sharing
  * Plugin URI:          https://woocommerce.com/products/storefront-product-sharing/
  * Description:         Add attractive social sharing icons for Facebook, Twitter, Pinterest and Email to your product pages.
- * Version:             1.0.6
+ * Version:             1.0.7
  * Author:              WooCommerce
  * Author URI:          https://woocommerce.com/
  * Requires at least:   4.0.0

--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -3,7 +3,7 @@
  * Plugin Name:         Storefront Product Sharing
  * Plugin URI:          https://woocommerce.com/products/storefront-product-sharing/
  * Description:         Add attractive social sharing icons for Facebook, Twitter, Pinterest and Email to your product pages.
- * Version:             1.0.7
+ * Version:             1.0.6
  * Author:              WooCommerce
  * Author URI:          https://woocommerce.com/
  * Requires at least:   4.0.0

--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -233,7 +233,7 @@ final class Storefront_Product_Sharing {
 		$product_img	= wp_get_attachment_url( get_post_thumbnail_id() );
 
 		$facebook_url 	= 'https://www.facebook.com/sharer/sharer.php?u=' . $product_url;
-		$twitter_url	= 'https://twitter.com/intent/tweet?status=' . rawurlencode( $product_title ) . '+' . $product_url;
+		$twitter_url	= 'https://twitter.com/share?text=' . rawurlencode( $product_title ) . '+' . $product_url;
 		$pinterest_url	= 'https://pinterest.com/pin/create/bookmarklet/?media=' . $product_img . '&url=' . $product_url . '&is_video=false&description=' . rawurlencode( $product_title );
 		$email_url		= 'mailto:?subject=' . rawurlencode( $product_title ) . '&body=' . $product_url;
 		?>

--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -233,7 +233,7 @@ final class Storefront_Product_Sharing {
 		$product_img	= wp_get_attachment_url( get_post_thumbnail_id() );
 
 		$facebook_url 	= 'https://www.facebook.com/sharer/sharer.php?u=' . $product_url;
-		$twitter_url	= 'https://twitter.com/share?text=' . rawurlencode( $product_title ) . '+' . $product_url;
+		$twitter_url	= 'https://twitter.com/intent/tweet?text=' . rawurlencode( $product_title ) . '&url=' . $product_url;
 		$pinterest_url	= 'https://pinterest.com/pin/create/bookmarklet/?media=' . $product_img . '&url=' . $product_url . '&is_video=false&description=' . rawurlencode( $product_title );
 		$email_url		= 'mailto:?subject=' . rawurlencode( $product_title ) . '&body=' . $product_url;
 		?>


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #15 

Corrected Twitter share URL from to include product data when sharing. Added to change and bumped version

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Enable plugin
2. Click Twitter Icon on customer-facing product page
3. See Product name and URL now included in the tweet

### Changelog

> * Fix - Twitter share URL.

### Tests

- [X] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [X] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [X] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [X] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
