### PR TITLE
#13 Fixed fontawesome being loaded twice when storefront or childs are active

### DIFF
--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -215,12 +215,6 @@ final class Storefront_Product_Sharing {
 	 * @return  void
 	 */
 	public function sps_styles() {
-		global $storefront_version;
-
-		if ( version_compare( $storefront_version, '2.3.0', '>=' ) ) {
-			wp_enqueue_style( 'font-awesome-5-brands', '//use.fontawesome.com/releases/v5.0.13/css/brands.css' );
-		}
-
 		wp_enqueue_style( 'sps-styles', plugins_url( '/assets/css/style.css', __FILE__ ) );
 	}
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #13 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Removed the code to load the font styles from the cdn


<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Instal WP Woo, Storefront theme and this plugin
2. Set storefront as theme and activate this plugin
3. Create a product
4. Visit the product page

### Changelog

> Dont load fontawesome styles since they are loaded from storefront