### PR TITLE
Enhancement - Use short URL and copy product link.

### DIFF
--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -3,7 +3,7 @@
  * Plugin Name:         Storefront Product Sharing
  * Plugin URI:          https://woocommerce.com/products/storefront-product-sharing/
  * Description:         Add attractive social sharing icons for Facebook, Twitter, Pinterest and Email to your product pages.
- * Version:             1.0.7
+ * Version:             1.0.8
  * Author:              WooCommerce
  * Author URI:          https://woocommerce.com/
  * Requires at least:   4.0

--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -3,11 +3,11 @@
  * Plugin Name:         Storefront Product Sharing
  * Plugin URI:          https://woocommerce.com/products/storefront-product-sharing/
  * Description:         Add attractive social sharing icons for Facebook, Twitter, Pinterest and Email to your product pages.
- * Version:             1.0.6
+ * Version:             1.0.7
  * Author:              WooCommerce
  * Author URI:          https://woocommerce.com/
- * Requires at least:   4.0.0
- * Tested up to:        4.9
+ * Requires at least:   4.0
+ * Tested up to:        5.8
  *
  * Text Domain: storefront-product-sharing
  * Domain Path: /languages/
@@ -229,20 +229,21 @@ final class Storefront_Product_Sharing {
 	 */
 	public function sps_product_sharing() {
 		$product_title 	= get_the_title();
-		$product_url	= get_permalink();
+		$product_url	= wp_get_shortlink();
 		$product_img	= wp_get_attachment_url( get_post_thumbnail_id() );
 
 		$facebook_url 	= 'https://www.facebook.com/sharer/sharer.php?u=' . $product_url;
-		$twitter_url	= 'https://twitter.com/intent/tweet?text=' . rawurlencode( $product_title ) . '&url=' . $product_url;
+		$twitter_url	= 'https://twitter.com/intent/tweet?status=' . rawurlencode( $product_title ) . '+' . $product_url;
 		$pinterest_url	= 'https://pinterest.com/pin/create/bookmarklet/?media=' . $product_img . '&url=' . $product_url . '&is_video=false&description=' . rawurlencode( $product_title );
 		$email_url		= 'mailto:?subject=' . rawurlencode( $product_title ) . '&body=' . $product_url;
 		?>
 		<div class="storefront-product-sharing">
 			<ul>
-				<li class="twitter"><a href="<?php echo esc_url( $twitter_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'Share on Twitter', 'storefront-product-sharing' ); ?></a></li>
-				<li class="facebook"><a href="<?php echo esc_url( $facebook_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'Share on Facebook', 'storefront-product-sharing' ); ?></a></li>
-				<li class="pinterest"><a href="<?php echo esc_url( $pinterest_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'Pin this product', 'storefront-product-sharing' ); ?></a></li>
-				<li class="email"><a href="<?php echo esc_url( $email_url ); ?>"><?php _e( 'Share via Email', 'storefront-product-sharing' ); ?></a></li>
+				<li class="product-link"><a href="<?php echo esc_url( $product_url ); ?>"><?php _e( 'Copy product link to share', 'storefront-product-sharing' ); ?></a></li>
+				<li class="twitter"><a href="<?php echo esc_url( $twitter_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'Share this product on Twitter', 'storefront-product-sharing' ); ?></a></li>
+				<li class="facebook"><a href="<?php echo esc_url( $facebook_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'Share this product on Facebook', 'storefront-product-sharing' ); ?></a></li>
+				<li class="pinterest"><a href="<?php echo esc_url( $pinterest_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'Pin this product on Pinterest', 'storefront-product-sharing' ); ?></a></li>
+				<li class="email"><a href="<?php echo esc_url( $email_url ); ?>"><?php _e( 'Share this product via Email', 'storefront-product-sharing' ); ?></a></li>
 			</ul>
 		</div>
 		<?php


### PR DESCRIPTION
Added get_shortlink in favour of full url get_permalink.
Added share product link button, (needs styling) , perfect for short domain url

tested up to WP 5.8 and Woo 5.6 on live site 

<!-- Reference any related issues or PRs here -->
Fixes # Links open in new tab, https://github.com/woocommerce/storefront-product-sharing/issues/11 
suggested to close.

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Changed the way url is displayed, better user experience, especially for short domains.

Added copy product link.

Requires some css changes.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->
1.
2.
3.

### Changelog

> Add suggested changelog entry here.

Tweak get_shortlink in favour of full url get_permalink.
Tweak copy product link button, perfect for short domain url
Tweak New copy product link needs styling to your taste. (advised to copy css file to theme child) 

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11  No
- [ ] I've tested using only a keyboard (no mouse) Yes
- [ ] I've tested using a screen reader No
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) No
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/) Unsure
