### PR TITLE
Fixed twice loading Fontawesome brands icons when Storefront theme is activated

### DIFF
--- a/storefront-product-sharing.php
+++ b/storefront-product-sharing.php
@@ -217,7 +217,7 @@ final class Storefront_Product_Sharing {
 	public function sps_styles() {
 		global $storefront_version;
 
-		if ( version_compare( $storefront_version, '2.3.0', '>=' ) ) {
+		if ( version_compare( $storefront_version, '2.5.6', '<=') ) {
 			wp_enqueue_style( 'font-awesome-5-brands', '//use.fontawesome.com/releases/v5.0.13/css/brands.css' );
 		}
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #13 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Fixed the needless loading of third-party CDN shunning twice loading brands icons when storefront theme is activated. As Fontawesome brands icons are part of the theme, as of Storefront 2.5.7, only previous versions will load brand icons from Fontawesome CDN.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Install WP Woo, Storefront theme and Storefront Product Sharing plugin
2. Set Storefront as theme and activate the plugin
3. Create a product
4. Visit the product page

### Changelog

> Improving Storefront theme page load by shunning needless loading of third-party CDN Fontawesome brands icons

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
